### PR TITLE
Migration from mapbox-gl-js to maplibre-gl-js

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "platform/android/vendor/mapbox-events-android"]
 	path = platform/android/vendor/mapbox-events-android
 	url = https://github.com/mapbox/mapbox-events-android.git
+[submodule "maplibre-gl-js"]
+	path = maplibre-gl-js
+	url = https://github.com/maplibre/maplibre-gl-js.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "mapbox-gl-js"]
-	path = mapbox-gl-js
-	url = https://github.com/mapbox/mapbox-gl-js.git
 [submodule "vendor/earcut.hpp"]
 	path = vendor/earcut.hpp
 	url = https://github.com/mapbox/earcut.hpp.git

--- a/expression-test/expression_test_parser.cpp
+++ b/expression-test/expression_test_parser.cpp
@@ -338,7 +338,7 @@ std::tuple<filesystem::path, std::vector<filesystem::path>, bool, uint32_t> pars
         exit(2);
     }
 
-    filesystem::path rootPath {std::string(TEST_RUNNER_ROOT_PATH).append("/mapbox-gl-js/test/integration/expression-tests")};
+    filesystem::path rootPath {std::string(TEST_RUNNER_ROOT_PATH).append("/maplibre-gl-js/test/integration/expression-tests")};
     if (!filesystem::exists(rootPath)) {
         Log::Error(Event::General, "Test path '%s' does not exist.", rootPath.string().c_str());
         exit(3);

--- a/metrics/FIXME-linux-asan-style.json
+++ b/metrics/FIXME-linux-asan-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/metrics/android-render-test-runner-style.json
+++ b/metrics/android-render-test-runner-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all",

--- a/metrics/linux-clang8-release-style.json
+++ b/metrics/linux-clang8-release-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/metrics/linux-gcc8-debug-coverage-style.json
+++ b/metrics/linux-gcc8-debug-coverage-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/metrics/linux-gcc8-release-style.json
+++ b/metrics/linux-gcc8-release-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/metrics/linux-tsan-style.json
+++ b/metrics/linux-tsan-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/metrics/linux-ubsan-style.json
+++ b/metrics/linux-ubsan-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/metrics/macos-xcode11-debug-style.json
+++ b/metrics/macos-xcode11-debug-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/metrics/macos-xcode11-release-style.json
+++ b/metrics/macos-xcode11-release-style.json
@@ -1,5 +1,5 @@
 {
-    "base_test_path": "../mapbox-gl-js/test/integration",
+    "base_test_path": "../maplibre-gl-js/test/integration",
     "cache_path": "cache-style.db",
     "expectation_paths": [
         "expectations/platform-all"

--- a/platform/android/CHANGELOG.md
+++ b/platform/android/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [`Contributing Guide`](https://github.com/mapbox/mapbox-gl-native/blob/master/CONTRIBUTING.md) to get started.
 
+## master
+
+### Features
+
+### Other
+
+* mapbox-gl-js submodule has been replaced with maplibre-gl-js
+
 ## 9.3.0 - January 6, 2021
 ### Features
  - Added the mbtiles file source for rendering vector tiles from file stored locally on the device.

--- a/platform/android/Makefile
+++ b/platform/android/Makefile
@@ -91,13 +91,13 @@ android-core-test-$1: android-test-lib-$1
 
 run-android-core-test-$1-%: android-core-test-$1
 	# Ensure clean state on the device
-	adb shell "rm -Rf $(MBGL_ANDROID_LOCAL_WORK_DIR) && mkdir -p $(MBGL_ANDROID_LOCAL_WORK_DIR)/test && mkdir -p $(MBGL_ANDROID_LOCAL_WORK_DIR)/mapbox-gl-js/src/style-spec/reference"
+	adb shell "rm -Rf $(MBGL_ANDROID_LOCAL_WORK_DIR) && mkdir -p $(MBGL_ANDROID_LOCAL_WORK_DIR)/test && mkdir -p $(MBGL_ANDROID_LOCAL_WORK_DIR)/maplibre-gl-js/src/style-spec/reference"
 
 	# Push all needed files to the device
 	adb push $(MBGL_ANDROID_CORE_TEST_DIR)/classes.dex $(MBGL_ANDROID_LOCAL_WORK_DIR) > /dev/null 2>&1
 	adb push MapboxGLAndroidSDK/build/intermediates/intermediate-jars/$(buildtype)/jni/$2/libmapbox-gl.so $(MBGL_ANDROID_LOCAL_WORK_DIR) > /dev/null 2>&1
 	adb push test/fixtures $(MBGL_ANDROID_LOCAL_WORK_DIR)/test > /dev/null 2>&1
-	adb push mapbox-gl-js/src/style-spec/reference/v8.json $(MBGL_ANDROID_LOCAL_WORK_DIR)/mapbox-gl-js/src/style-spec/reference > /dev/null 2>&1
+	adb push maplibre-gl-js/src/style-spec/reference/v8.json $(MBGL_ANDROID_LOCAL_WORK_DIR)/maplibre-gl-js/src/style-spec/reference > /dev/null 2>&1
 	adb push MapboxGLAndroidSDK/build/intermediates/cmake/$(buildtype)/obj/$2/mbgl-test $(MBGL_ANDROID_LOCAL_WORK_DIR) > /dev/null 2>&1
 
 # Create gtest filter for skipped tests.
@@ -176,7 +176,7 @@ run-android-render-test-$1: $(BUILD_DEPS) gradle/configuration.gradle
 	rm -rf build/render-test/mapbox/
   # copy test definitions & ignore file to test app assets folder, clear old ones first
 	rm -rf MapboxGLAndroidSDKTestApp/src/main/assets/integration
-	cp -r mapbox-gl-js/test/integration MapboxGLAndroidSDKTestApp/src/main/assets
+	cp -r maplibre-gl-js/test/integration MapboxGLAndroidSDKTestApp/src/main/assets
 	cp platform/node/test/ignores.json MapboxGLAndroidSDKTestApp/src/main/assets/integration/ignores.json
 	# run RenderTest.java to generate static map images
 	$(MBGL_ANDROID_GRADLE) -Pmapbox.abis=$2 :MapboxGLAndroidSDKTestApp:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="com.mapbox.mapboxsdk.testapp.render.RenderTest"

--- a/platform/android/scripts/run-render-test.py
+++ b/platform/android/scripts/run-render-test.py
@@ -9,7 +9,7 @@ testCounter = 0
 for cat in os.listdir(catPath):
     testPath = catPath + cat + "/"
     for test in os.listdir(testPath):
-        inputPath = os.getcwd() + "../../../mapbox-gl-js/test/integration/render-tests/" + cat + "/" + test
+        inputPath = os.getcwd() + "../../../maplibre-gl-js/test/integration/render-tests/" + cat + "/" + test
         outputPath = testPath + test
 
         expected = outputPath + "/expected.png"

--- a/platform/glfw/glfw_view.cpp
+++ b/platform/glfw/glfw_view.cpp
@@ -415,7 +415,7 @@ void GLFWView::onKey(GLFWwindow *window, int key, int /*scancode*/, int action, 
 
             auto &style = view->map->getStyle();
             if (!style.getSource("states")) {
-                std::string url = "https://docs.mapbox.com/mapbox-gl-js/assets/us_states.geojson";
+                std::string url = "https://docs.mapbox.com/maplibre-gl-js/assets/us_states.geojson";
                 auto source = std::make_unique<GeoJSONSource>("states");
                 source->setURL(url);
                 style.addSource(std::move(source));

--- a/platform/ios/.npmignore
+++ b/platform/ios/.npmignore
@@ -14,6 +14,7 @@ vendor
 include
 mason_packages
 mapbox-gl-js
+maplibre-gl-js
 test
 lib
 next

--- a/platform/ios/ios-test-runners.cmake
+++ b/platform/ios/ios-test-runners.cmake
@@ -91,8 +91,8 @@ if(MBGL_IOS_UNIT_TEST)
     execute_process(COMMAND ditto ${PROJECT_SOURCE_DIR}/test/fixtures ${CMAKE_CURRENT_BINARY_DIR}/test-data/test/fixtures)
     execute_process(
         COMMAND
-            ditto ${PROJECT_SOURCE_DIR}/mapbox-gl-js/src/style-spec/reference
-            ${CMAKE_CURRENT_BINARY_DIR}/test-data/mapbox-gl-js/src/style-spec/reference
+            ditto ${PROJECT_SOURCE_DIR}/maplibre-gl-js/src/style-spec/reference
+            ${CMAKE_CURRENT_BINARY_DIR}/test-data/maplibre-gl-js/src/style-spec/reference
     )
 
     set(RESOURCES ${PROJECT_SOURCE_DIR}/platform/ios/test/common/Main.storyboard

--- a/platform/ios/platform/ios/CHANGELOG.md
+++ b/platform/ios/platform/ios/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Mapbox welcomes participation and contributions from everyone. Please read [CONTRIBUTING.md](../../CONTRIBUTING.md) to get started.
 
+## master
+
+### Features
+
+### Other
+
+* mapbox-gl-js submodule has been replaced with maplibre-gl-js
 
 ## 5.10.0 - January 6, 2021
 

--- a/platform/ios/platform/macos/CHANGELOG.md
+++ b/platform/ios/platform/macos/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for Mapbox Maps SDK for macOS
 
+## master
+
+### Features
+
+### Other
+
+* mapbox-gl-js submodule has been replaced with maplibre-gl-js
+
 ## 0.17.0 - January 6, 2021
 
 ### Features

--- a/platform/ios/scripts/generate-shaders.js
+++ b/platform/ios/scripts/generate-shaders.js
@@ -7,7 +7,7 @@ const outputPath = 'src/mbgl/programs';
 const zlib = require('zlib');
 const crypto = require('crypto');
 
-var shaders = require('../mapbox-gl-js/src/shaders');
+var shaders = require('../maplibre-gl-js/src/shaders');
 
 require('./style-code');
 

--- a/platform/ios/scripts/nitpick/submodule-pin.js
+++ b/platform/ios/scripts/nitpick/submodule-pin.js
@@ -2,12 +2,12 @@
 const nitpick = require('.');
 const child_process = require('child_process');
 
-// Make sure that the mapbox-gl-js submodule pin is up to date
-const head = child_process.execSync('git -C mapbox-gl-js rev-parse HEAD').toString().trim();
-const revs = child_process.execSync(`git -C mapbox-gl-js branch -a --contains ${head}`).toString().split('\n');
+// Make sure that the maplibre-gl-js submodule pin is up to date
+const head = child_process.execSync('git -C maplibre-gl-js rev-parse HEAD').toString().trim();
+const revs = child_process.execSync(`git -C maplibre-gl-js branch -a --contains ${head}`).toString().split('\n');
 
 if (revs.indexOf('  remotes/origin/master') >= 0) {
-    nitpick.ok(`mapbox-gl-js submodule pin is merged to master`);
+    nitpick.ok(`maplibre-gl-js submodule pin is merged to master`);
 } else {
-    nitpick.fail(`mapbox-gl-js submodule is pinned to ${head}, which isn't merged to master`);
+    nitpick.fail(`maplibre-gl-js submodule is pinned to ${head}, which isn't merged to master`);
 }

--- a/platform/ios/scripts/style-spec.js
+++ b/platform/ios/scripts/style-spec.js
@@ -1,1 +1,1 @@
-module.exports = require('../../../mapbox-gl-js/src/style-spec/reference/v8');
+module.exports = require('../../../maplibre-gl-js/src/style-spec/reference/v8');

--- a/platform/node/test/expression.test.js
+++ b/platform/node/test/expression.test.js
@@ -1,4 +1,4 @@
-const {run} = require('../../../mapbox-gl-js/test/integration/lib/expression');
+const {run} = require('../../../maplibre-gl-js/test/integration/lib/expression');
 const mbgl = require('../index');
 const ignores = require('./ignores.json');
 

--- a/platform/node/test/query.test.js
+++ b/platform/node/test/query.test.js
@@ -1,4 +1,4 @@
-import {run} from '../../../mapbox-gl-js/test/integration/lib/query';
+import {run} from '../../../maplibre-gl-js/test/integration/lib/query';
 import implementation from './suite_implementation';
 import ignores from './ignores.json';
 

--- a/platform/node/test/render.test.js
+++ b/platform/node/test/render.test.js
@@ -1,4 +1,4 @@
-import {run} from '../../../mapbox-gl-js/test/integration/lib/render';
+import {run} from '../../../maplibre-gl-js/test/integration/lib/render';
 import implementation from './suite_implementation';
 import ignores from './ignores.json';
 

--- a/platform/node/test/suite_implementation.js
+++ b/platform/node/test/suite_implementation.js
@@ -104,7 +104,7 @@ export default function (style, options, callback) {
                 applyOperations(operations.slice(1), callback);
             }, operation[1]);
         } else if (operation[0] === 'addImage' || operation[0] === 'updateImage') {
-            const img = PNG.sync.read(fs.readFileSync(path.join(__dirname, '../../../mapbox-gl-js/test/integration', operation[2])));
+            const img = PNG.sync.read(fs.readFileSync(path.join(__dirname, '../../../maplibre-gl-js/test/integration', operation[2])));
             const testOpts = (operation.length > 3) ? operation[3] : {};
 
             const options = {

--- a/render-test/android/app/src/main/assets/to_zip.txt
+++ b/render-test/android/app/src/main/assets/to_zip.txt
@@ -1,5 +1,5 @@
-mapbox-gl-js/test/integration/render-tests/
-mapbox-gl-js/test/integration/query-tests/
+maplibre-gl-js/test/integration/render-tests/
+maplibre-gl-js/test/integration/query-tests/
 metrics/expectations/
 metrics/ignores/
 metrics/tests/

--- a/render-test/ios/setup_test_data.sh
+++ b/render-test/ios/setup_test_data.sh
@@ -12,8 +12,8 @@ rm -rf $BASE_DIR/test-data/
 mkdir -p $BASE_DIR/test-data/integration/
 mkdir -p $BASE_DIR/test-data/baselines/
 
-cp -r mapbox-gl-js/test/integration/render-tests $BASE_DIR/test-data/integration/
-cp -r mapbox-gl-js/test/integration/query-tests $BASE_DIR/test-data/integration/
+cp -r maplibre-gl-js/test/integration/render-tests $BASE_DIR/test-data/integration/
+cp -r maplibre-gl-js/test/integration/query-tests $BASE_DIR/test-data/integration/
 cp -r metrics/expectations $BASE_DIR/test-data/
 cp -r metrics/ignores $BASE_DIR/test-data/
 cp -r metrics/tests $BASE_DIR/test-data/

--- a/scripts/generate-shaders.js
+++ b/scripts/generate-shaders.js
@@ -7,7 +7,7 @@ const outputPath = 'src/mbgl/programs';
 const zlib = require('zlib');
 const crypto = require('crypto');
 
-var shaders = require('../mapbox-gl-js/src/shaders');
+var shaders = require('../maplibre-gl-js/src/shaders');
 
 require('./style-code');
 

--- a/scripts/nitpick/submodule-pin.js
+++ b/scripts/nitpick/submodule-pin.js
@@ -2,12 +2,12 @@
 const nitpick = require('.');
 const child_process = require('child_process');
 
-// Make sure that the mapbox-gl-js submodule pin is up to date
-const head = child_process.execSync('git -C mapbox-gl-js rev-parse HEAD').toString().trim();
-const revs = child_process.execSync(`git -C mapbox-gl-js branch -a --contains ${head}`).toString().split('\n');
+// Make sure that the maplibre-gl-js submodule pin is up to date
+const head = child_process.execSync('git -C maplibre-gl-js rev-parse HEAD').toString().trim();
+const revs = child_process.execSync(`git -C maplibre-gl-js branch -a --contains ${head}`).toString().split('\n');
 
 if (revs.indexOf('  remotes/origin/master') >= 0) {
-    nitpick.ok(`mapbox-gl-js submodule pin is merged to master`);
+    nitpick.ok(`maplibre-gl-js submodule pin is merged to master`);
 } else {
-    nitpick.fail(`mapbox-gl-js submodule is pinned to ${head}, which isn't merged to master`);
+    nitpick.fail(`maplibre-gl-js submodule is pinned to ${head}, which isn't merged to master`);
 }

--- a/scripts/style-spec.js
+++ b/scripts/style-spec.js
@@ -1,4 +1,4 @@
-const referenceSpec = require('../mapbox-gl-js/src/style-spec/reference/v8');
+const referenceSpec = require('../maplibre-gl-js/src/style-spec/reference/v8');
 
 referenceSpec.layer.type.values["location-indicator"] = {};
 referenceSpec["layout_location-indicator"] = {

--- a/test/android/app/src/main/assets/to_zip.txt
+++ b/test/android/app/src/main/assets/to_zip.txt
@@ -1,3 +1,3 @@
 test/results/
 test/fixtures/
-mapbox-gl-js/src/style-spec/reference/
+maplibre-gl-js/src/style-spec/reference/

--- a/test/map/transform.test.cpp
+++ b/test/map/transform.test.cpp
@@ -110,7 +110,7 @@ TEST(Transform, PerspectiveProjection) {
     // 0.9 rad ~ 51.56620156 deg
     transform.jumpTo(CameraOptions().withCenter(LatLng { 38.0, -77.0 }).withZoom(10.0).withPitch(51.56620156));
 
-    // expected values are from mapbox-gl-js
+    // expected values are from maplibre-gl-js
 
     loc = transform.getLatLng();
     ASSERT_DOUBLE_EQ(-77, loc.longitude());

--- a/test/style/expression/expression.test.cpp
+++ b/test/style/expression/expression.test.cpp
@@ -17,7 +17,7 @@ using namespace mbgl::style;
 
 TEST(Expression, IsExpression) {
     rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::CrtAllocator> spec;
-    spec.Parse<0>(util::read_file("mapbox-gl-js/src/style-spec/reference/v8.json").c_str());
+    spec.Parse<0>(util::read_file("maplibre-gl-js/src/style-spec/reference/v8.json").c_str());
     ASSERT_FALSE(spec.HasParseError());
     ASSERT_TRUE(spec.IsObject() &&
                 spec.HasMember("expression_name") &&


### PR DESCRIPTION
## Migration from mapbox-gl-js to maplibre-gl-js

* mapbox-gl-js submodule replaced with maplibre-gl-js
* References to mapbox-gl-js updated to maplibre-gl-js