### PR TITLE
Add mbtiles_file_source.cpp in linux.cmake

### DIFF
--- a/platform/linux/linux.cmake
+++ b/platform/linux/linux.cmake
@@ -26,6 +26,7 @@ target_sources(
         $<$<BOOL:${MBGL_PUBLIC_BUILD}>:${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/http_file_source.cpp>
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/local_file_request.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/local_file_source.cpp
+        ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/mbtiles_file_source.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/main_resource_loader.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/offline.cpp
         ${PROJECT_SOURCE_DIR}/platform/default/src/mbgl/storage/offline_database.cpp


### PR DESCRIPTION
The following error appears when using maplibre-gl-native from Java with [JNI bindings](https://github.com/baremaps/maplibre-java) on linux:

```
java: symbol lookup error: /tmp/libmaplibre-native-13994025245107934612.so: undefined symbol: _ZN4mbgl18MaptilerFileSourceC1Ev
```

Adding `mbtiles_file_source.cpp` in `linux.cmake` solves the issue.